### PR TITLE
need to copy composer.json when upgrading

### DIFF
--- a/getting-started/upgrading.md
+++ b/getting-started/upgrading.md
@@ -29,7 +29,7 @@ lets tar gzip it to a safe location.
 
 1.	Download the [latest version](/download)
 2.	Extract the archive and copy/paste/overwrite the `anchor` and `system`
-	folders and the `index.php` file.
+	folders, and the `index.php` and `composer.json` files.
 3.	Rename `anchor/config/database.php` --> `anchor/config/db.php`
 4.	Rename `anchor/config/application.php` --> `anchor/config/app.php`
 5.	Done!


### PR DESCRIPTION
I had a spot of trouble upgrading from 0.9.2 to 0.12.1, and it was because I needed the new `composer.json` file.

The `composer.json` file was updated in 0.10, I think, so anyone below that needs to copy it over.